### PR TITLE
feat: OTel collector for logs/metrics/traces, exported to Better Stack

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,5 +50,6 @@ This repository contains the infrastructure-as-code for [willpxxr.com](https://w
 
 - `var.cloudflare_api_token` — Cloudflare API token
 - `var.oci_rsa_private_key_base64enc` — OCI RSA private key (base64-encoded)
+- `var.betterstack_api_token` — Better Stack Telemetry API token
 
 These must never appear in plain text in any file.

--- a/betterstack.tf
+++ b/betterstack.tf
@@ -1,0 +1,32 @@
+# Better Stack Telemetry source for the cluster-wide OTel Collector
+# (gitops: apps/otel-collector-agent/, apps/otel-collector-gateway/). Using
+# the provider (rather than pasting a token created by hand in the
+# dashboard) means the source token and ingesting host are never typed
+# in manually -- both are Computed+Sensitive attributes populated only on
+# create, written straight into the same 1Password vault the cluster's
+# ExternalSecrets already read from.
+resource "logtail_source" "otel_collector" {
+  name     = "willpxxr-live-otel-collector"
+  platform = "open_telemetry"
+}
+
+resource "onepassword_item" "betterstack_otel" {
+  vault    = data.onepassword_vault.kubernetes.uuid
+  title    = "betterstack-otel"
+  category = "login"
+
+  section_map = {
+    credentials = {
+      field_map = {
+        source_token = {
+          type  = "CONCEALED"
+          value = logtail_source.otel_collector.token
+        }
+        ingesting_host = {
+          type  = "STRING"
+          value = logtail_source.otel_collector.ingesting_host
+        }
+      }
+    }
+  }
+}

--- a/gitops/clusters/de/hetzner/cluster/apps/envoy-gateway-config/envoyproxy.yaml
+++ b/gitops/clusters/de/hetzner/cluster/apps/envoy-gateway-config/envoyproxy.yaml
@@ -15,3 +15,16 @@ spec:
           tailscale.com/hostname: "gateway"
           tailscale.com/proxy-group: "ingress"
           tailscale.com/tags: "tag:services"
+  # Sends traces for every route handled by this Gateway (including the
+  # AI gateway and Auth0-protected routes) to the gateway collector's otlp
+  # receiver -- see apps/otel-collector-gateway/. Cross-namespace backendRef
+  # requires the ReferenceGrant in apps/otel-collector-gateway/referencegrant.yaml.
+  telemetry:
+    tracing:
+      samplingRate: 10
+      provider:
+        type: OpenTelemetry
+        backendRefs:
+          - name: otel-collector-gateway
+            namespace: otel-collector
+            port: 4317

--- a/gitops/clusters/de/hetzner/cluster/apps/otel-collector-agent/config.yaml
+++ b/gitops/clusters/de/hetzner/cluster/apps/otel-collector-agent/config.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSetInputProvider
+metadata:
+  name: otel-collector-agent
+  namespace: flux-system
+  labels:
+    fluxcd.controlplane.io/resourceset: charts
+spec:
+  type: Static
+  defaultValues:
+    name: "otel-collector-agent"
+    namespace: "otel-collector"
+    repoURL: "https://open-telemetry.github.io/opentelemetry-helm-charts"
+    chart: "opentelemetry-collector"
+    valuesConfigMap: "otel-collector-agent-values"

--- a/gitops/clusters/de/hetzner/cluster/apps/otel-collector-agent/kustomization.yaml
+++ b/gitops/clusters/de/hetzner/cluster/apps/otel-collector-agent/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - config.yaml
+configMapGenerator:
+  - name: otel-collector-agent-values
+    namespace: flux-system
+    files:
+      - values.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/gitops/clusters/de/hetzner/cluster/apps/otel-collector-agent/values.yaml
+++ b/gitops/clusters/de/hetzner/cluster/apps/otel-collector-agent/values.yaml
@@ -1,0 +1,69 @@
+mode: daemonset
+nameOverride: otel-collector-agent
+fullnameOverride: otel-collector-agent
+
+# contrib, not core -- hostmetrics/kubeletstats/filelog/k8sattributes are
+# all contrib-only receivers/processors (confirmed via `helm template`,
+# the chart no longer defaults this and fails closed if unset).
+image:
+  repository: otel/opentelemetry-collector-contrib
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+presets:
+  hostMetrics:
+    enabled: true
+  kubeletMetrics:
+    enabled: true
+  kubernetesAttributes:
+    enabled: true
+  logsCollection:
+    enabled: true
+
+# This node's own agent handles traces/jaeger/zipkin ingestion nowhere --
+# only the gateway deployment receives push-based signals (Envoy traces).
+ports:
+  jaeger-compact:
+    enabled: false
+  jaeger-thrift:
+    enabled: false
+  jaeger-grpc:
+    enabled: false
+  zipkin:
+    enabled: false
+
+extraEnvs:
+  - name: BETTERSTACK_SOURCE_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: betterstack-otel
+        key: sourceToken
+  - name: BETTERSTACK_INGESTING_HOST
+    valueFrom:
+      secretKeyRef:
+        name: betterstack-otel
+        key: ingestingHost
+
+config:
+  exporters:
+    otlphttp/betterstack:
+      endpoint: "https://${env:BETTERSTACK_INGESTING_HOST}"
+      headers:
+        Authorization: "Bearer ${env:BETTERSTACK_SOURCE_TOKEN}"
+  service:
+    pipelines:
+      logs:
+        exporters:
+          - otlphttp/betterstack
+      metrics:
+        exporters:
+          - otlphttp/betterstack
+      traces:
+        exporters:
+          - otlphttp/betterstack

--- a/gitops/clusters/de/hetzner/cluster/apps/otel-collector-gateway/config.yaml
+++ b/gitops/clusters/de/hetzner/cluster/apps/otel-collector-gateway/config.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSetInputProvider
+metadata:
+  name: otel-collector-gateway
+  namespace: flux-system
+  labels:
+    fluxcd.controlplane.io/resourceset: charts
+spec:
+  type: Static
+  defaultValues:
+    name: "otel-collector-gateway"
+    namespace: "otel-collector"
+    repoURL: "https://open-telemetry.github.io/opentelemetry-helm-charts"
+    chart: "opentelemetry-collector"
+    valuesConfigMap: "otel-collector-gateway-values"

--- a/gitops/clusters/de/hetzner/cluster/apps/otel-collector-gateway/kustomization.yaml
+++ b/gitops/clusters/de/hetzner/cluster/apps/otel-collector-gateway/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - config.yaml
+  - referencegrant.yaml
+configMapGenerator:
+  - name: otel-collector-gateway-values
+    namespace: flux-system
+    files:
+      - values.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/gitops/clusters/de/hetzner/cluster/apps/otel-collector-gateway/referencegrant.yaml
+++ b/gitops/clusters/de/hetzner/cluster/apps/otel-collector-gateway/referencegrant.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-envoy-gateway-tracing
+  namespace: otel-collector
+spec:
+  from:
+    - group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      namespace: envoy-gateway-system
+  to:
+    - group: ""
+      kind: Service
+      name: otel-collector-gateway

--- a/gitops/clusters/de/hetzner/cluster/apps/otel-collector-gateway/values.yaml
+++ b/gitops/clusters/de/hetzner/cluster/apps/otel-collector-gateway/values.yaml
@@ -1,0 +1,109 @@
+mode: deployment
+nameOverride: otel-collector-gateway
+fullnameOverride: otel-collector-gateway
+
+# contrib, not core -- k8s_cluster/k8sobjects/k8sattributes/prometheus'
+# kubernetes_sd_configs are all contrib-only (confirmed via `helm
+# template`, the chart no longer defaults this and fails closed if unset).
+image:
+  repository: otel/opentelemetry-collector-contrib
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+presets:
+  # k8s_cluster receiver -- cluster-level metrics (node/pod/deployment
+  # counts and phases), one collector only, hence deployment not daemonset.
+  clusterMetrics:
+    enabled: true
+  kubernetesAttributes:
+    enabled: true
+  # k8sobjects receiver -- Kubernetes events (Warning/Normal) as logs.
+  kubernetesEvents:
+    enabled: true
+
+# Only otlp (for Envoy's traces, see apps/envoy-gateway-config/) and the
+# annotation-scraped prometheus receiver below are actually used here.
+ports:
+  jaeger-compact:
+    enabled: false
+  jaeger-thrift:
+    enabled: false
+  jaeger-grpc:
+    enabled: false
+  zipkin:
+    enabled: false
+
+extraEnvs:
+  - name: BETTERSTACK_SOURCE_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: betterstack-otel
+        key: sourceToken
+  - name: BETTERSTACK_INGESTING_HOST
+    valueFrom:
+      secretKeyRef:
+        name: betterstack-otel
+        key: ingestingHost
+
+config:
+  receivers:
+    # Replaces the chart's default self-scrape-only config wholesale
+    # (scrape_configs is a list, so this fully overrides rather than
+    # merging) -- the first job keeps that self-scrape, the second
+    # auto-discovers any pod in the cluster carrying the prometheus.io/scrape
+    # annotation (already set today by cert-manager and Envoy Gateway's
+    # control plane; picks up future components with no config change here).
+    prometheus:
+      config:
+        scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: 10s
+            static_configs:
+              - targets:
+                  - ${env:MY_POD_IP}:8888
+          - job_name: kubernetes-pods
+            kubernetes_sd_configs:
+              - role: pod
+            relabel_configs:
+              - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                action: keep
+                regex: "true"
+              - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+                action: replace
+                target_label: __metrics_path__
+                regex: (.+)
+              - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+                action: replace
+                regex: ([^:]+)(?::\d+)?;(\d+)
+                replacement: $1:$2
+                target_label: __address__
+              - action: labelmap
+                regex: __meta_kubernetes_pod_label_(.+)
+              - source_labels: [__meta_kubernetes_namespace]
+                action: replace
+                target_label: k8s.namespace.name
+              - source_labels: [__meta_kubernetes_pod_name]
+                action: replace
+                target_label: k8s.pod.name
+  exporters:
+    otlphttp/betterstack:
+      endpoint: "https://${env:BETTERSTACK_INGESTING_HOST}"
+      headers:
+        Authorization: "Bearer ${env:BETTERSTACK_SOURCE_TOKEN}"
+  service:
+    pipelines:
+      logs:
+        exporters:
+          - otlphttp/betterstack
+      metrics:
+        exporters:
+          - otlphttp/betterstack
+      traces:
+        exporters:
+          - otlphttp/betterstack

--- a/gitops/clusters/de/hetzner/cluster/apps/otel-collector/externalsecret.yaml
+++ b/gitops/clusters/de/hetzner/cluster/apps/otel-collector/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: betterstack-otel
+  namespace: otel-collector
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: betterstack-otel
+    creationPolicy: Owner
+  data:
+    - secretKey: sourceToken
+      remoteRef:
+        key: betterstack-otel/credentials/source_token
+    - secretKey: ingestingHost
+      remoteRef:
+        key: betterstack-otel/credentials/ingesting_host

--- a/gitops/clusters/de/hetzner/cluster/apps/otel-collector/kustomization.yaml
+++ b/gitops/clusters/de/hetzner/cluster/apps/otel-collector/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - network-policy.yaml
+  - externalsecret.yaml

--- a/gitops/clusters/de/hetzner/cluster/apps/otel-collector/namespace.yaml
+++ b/gitops/clusters/de/hetzner/cluster/apps/otel-collector/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: otel-collector

--- a/gitops/clusters/de/hetzner/cluster/apps/otel-collector/network-policy.yaml
+++ b/gitops/clusters/de/hetzner/cluster/apps/otel-collector/network-policy.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: otel-collector
+spec:
+  description: "Baseline consistent with the rest of the repo's per-namespace policies, even though the agent daemonset and gateway deployment don't actually need to talk to each other -- both export straight to Better Stack."
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: otel-collector
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: otel-collector
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: otel-collector
+spec:
+  description: "DNS resolution via CoreDNS, required to resolve the Better Stack ingesting host."
+  endpointSelector: {}
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+            io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-kube-apiserver-egress
+  namespace: otel-collector
+spec:
+  description: "Both collectors watch/read Kubernetes objects via the API server: the k8sattributes processor (pod metadata enrichment), the gateway's k8s_cluster and k8sobjects receivers (cluster metrics, events), and the agent's kubeletstats receiver (node auth)."
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-betterstack-egress
+  namespace: otel-collector
+spec:
+  description: "Both collectors export logs/metrics/traces to Better Stack's OTLP ingesting host over HTTPS; its IPs aren't enumerable so this allows general internet egress on 443, same pattern as the other allow-*-egress rules in this repo for third-party SaaS endpoints (e.g. apps/ai-gateway-llm/, apps/envoy-gateway/)."
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-kubelet-egress
+  namespace: otel-collector
+spec:
+  description: "The agent daemonset's kubeletstats receiver reads node/pod/container metrics from its own node's kubelet API."
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: otel-collector-agent
+  egress:
+    - toEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "10250"
+              protocol: TCP
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-envoy-gateway-tracing-ingress
+  namespace: otel-collector
+spec:
+  description: "The Envoy data-plane pods (apps/envoy-gateway-config/) export traces via OTLP/gRPC to the gateway collector's otlp receiver."
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: otel-collector-gateway
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: envoy-gateway-system
+      toPorts:
+        - ports:
+            - port: "4317"
+              protocol: TCP

--- a/gitops/clusters/de/hetzner/cluster/flux-system/kustomization-otel-collector-agent.yaml
+++ b/gitops/clusters/de/hetzner/cluster/flux-system/kustomization-otel-collector-agent.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: otel-collector-agent
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: "./gitops/clusters/de/hetzner/cluster/apps/otel-collector-agent"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  dependsOn:
+    - name: otel-collector
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: otel-collector-agent
+      namespace: flux-system

--- a/gitops/clusters/de/hetzner/cluster/flux-system/kustomization-otel-collector-gateway.yaml
+++ b/gitops/clusters/de/hetzner/cluster/flux-system/kustomization-otel-collector-gateway.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: otel-collector-gateway
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: "./gitops/clusters/de/hetzner/cluster/apps/otel-collector-gateway"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  dependsOn:
+    - name: otel-collector
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: otel-collector-gateway
+      namespace: flux-system

--- a/gitops/clusters/de/hetzner/cluster/flux-system/kustomization-otel-collector.yaml
+++ b/gitops/clusters/de/hetzner/cluster/flux-system/kustomization-otel-collector.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: otel-collector
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: "./gitops/clusters/de/hetzner/cluster/apps/otel-collector"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  dependsOn:
+    - name: external-secrets-secretstore

--- a/gitops/clusters/de/hetzner/cluster/flux-system/kustomization.yaml
+++ b/gitops/clusters/de/hetzner/cluster/flux-system/kustomization.yaml
@@ -20,3 +20,6 @@ resources:
 - kustomization-envoy-ai-gateway.yaml
 - kustomization-ai-gateway-llm.yaml
 - kustomization-ai-gateway-mcp.yaml
+- kustomization-otel-collector.yaml
+- kustomization-otel-collector-agent.yaml
+- kustomization-otel-collector-gateway.yaml

--- a/providers.tf
+++ b/providers.tf
@@ -61,6 +61,10 @@ terraform {
       source  = "cloudopsworks/openrouter"
       version = "~> 0.2"
     }
+    logtail = {
+      source  = "BetterStackHQ/logtail"
+      version = "~> 10.9"
+    }
   }
 }
 
@@ -101,4 +105,8 @@ provider "auth0" {
 
 provider "openrouter" {
   api_key = var.openrouter_api_key
+}
+
+provider "logtail" {
+  api_token = var.betterstack_api_token
 }

--- a/variables.tf
+++ b/variables.tf
@@ -45,3 +45,8 @@ variable "openrouter_api_key" {
   sensitive   = true
   description = "OpenRouter provisioning/management API key (from OpenRouter's dashboard), used to authenticate the openrouter Terraform provider so it can create scoped API keys via openrouter_api_key. Distinct from any regular per-app API key."
 }
+
+variable "betterstack_api_token" {
+  sensitive   = true
+  description = "Better Stack Telemetry API token (from https://betterstack.com/docs/logs/api/getting-started/#get-an-logs-api-token), used to authenticate the logtail Terraform provider so it can create the OTel Collector's Source via logtail_source. Distinct from the source token that resource then produces."
+}


### PR DESCRIPTION
## Summary
- Deploys an OpenTelemetry Collector as a node-level agent (host metrics, kubelet stats, container log tailing) + a cluster-level gateway (k8s_cluster metrics, k8s events, annotation-discovered Prometheus scraping, OTLP receiver), both exporting to Better Stack over OTLP/HTTP.
- Provisions the Better Stack source itself via the `BetterStackHQ/logtail` Terraform provider (`betterstack.tf`), writing the resulting source token/ingesting host into the existing `kubernetes` 1Password vault rather than pasting a token in by hand.
- Wires Envoy Gateway's data-plane tracing (10% sampled) to the new gateway collector, since it's the one existing component not already emitting metrics/logs on its own — requires the added `ReferenceGrant` for the cross-namespace backendRef.

## Requires before merge/apply
- A Terraform Cloud workspace variable `betterstack_api_token` (sensitive) — a Better Stack Telemetry API token, see the description on `var.betterstack_api_token` in `variables.tf` for where to get one. Without it, `terraform apply` will fail on the new `logtail` provider.

## Test plan
- [x] `terraform fmt -check` clean on all changed/new `.tf` files
- [x] All new/changed k8s manifests validated via `kubectl apply --dry-run=client` against the live cluster's CRDs (EnvoyProxy, ReferenceGrant, CiliumNetworkPolicy, ExternalSecret, ResourceSetInputProvider)
- [x] Both Helm releases (`otel-collector-agent`, `otel-collector-gateway`) rendered via `helm template` against the actual `open-telemetry/opentelemetry-collector` chart to confirm pipelines/exporters/RBAC/Service came out as intended
- [ ] `terraform plan` in Terraform Cloud once `betterstack_api_token` is set
- [ ] Flux reconciliation on merge — confirm both collector pods come up healthy and Better Stack starts receiving data

🤖 Generated with [Claude Code](https://claude.com/claude-code)